### PR TITLE
Handle HTML Response JSON Values

### DIFF
--- a/src/main/java/com/gizasystems/automationexercise/apis/ApisAccountManagement.java
+++ b/src/main/java/com/gizasystems/automationexercise/apis/ApisAccountManagement.java
@@ -1,5 +1,6 @@
 package com.gizasystems.automationexercise.apis;
 
+import com.gizasystems.automationexercise.utils.HtmlResponse;
 import com.shaft.api.RestActions;
 import com.shaft.driver.SHAFT;
 import io.qameta.allure.Step;
@@ -95,26 +96,38 @@ public class ApisAccountManagement {
     //////////////////// Validations \\\\\\\\\\\\\\\\\\\\
     @Step("Validate User Created/Registered")
     public ApisAccountManagement validateUserCreatedRegistered() {
-//        api.verifyThatResponse().extractedJsonValue("message").contains(expectedMessage).perform();
-        api.verifyThatResponse().body().contains("User created!").perform();
+//        api.verifyThatResponse().extractedJsonValue("message").isEqualTo("User created!").perform();
+        SHAFT.Validations.assertThat()
+                .object(HtmlResponse.getResponseJSONValue("message"))
+                .isEqualTo("User created!")
+                .perform();
         return this;
     }
 
 @Step("Validate User Login")
 public ApisAccountManagement validateUserLoggedIn() {
-        api.verifyThatResponse().body().contains("User exists!").perform();
+    SHAFT.Validations.assertThat()
+            .object(HtmlResponse.getResponseJSONValue("message"))
+            .isEqualTo("User exists!")
+            .perform();
         return this;
 }
     @Step("Validate Account Deleted")
     public ApisAccountManagement validateDeleteUser() {
-        api.verifyThatResponse().body().contains("Account deleted!").perform();
+        SHAFT.Validations.assertThat()
+                .object(HtmlResponse.getResponseJSONValue("message"))
+                .isEqualTo("Account deleted!")
+                .perform();
         return this;
     }
 
     @Step("Validate User Not Found in the System")
     public ApisAccountManagement validateUserNotFound(String email) {
         getUserDetailByEmail(email);
-        api.verifyThatResponse().body().contains("Account not found with this email, try another email!").perform();
+        SHAFT.Validations.assertThat()
+                .object(HtmlResponse.getResponseJSONValue("message"))
+                .isEqualTo("Account not found with this email, try another email!")
+                .perform();
         return this;
     }
 

--- a/src/main/java/com/gizasystems/automationexercise/utils/HtmlResponse.java
+++ b/src/main/java/com/gizasystems/automationexercise/utils/HtmlResponse.java
@@ -23,21 +23,20 @@ public class HtmlResponse {
      */
     public static String getResponseJSONValue(String jsonPath) {
         String searchPool = "";
+        String jsonResponse = RestActions.getLastResponse().asPrettyString();
+        String jsonObject = jsonResponse.substring(jsonResponse.indexOf("{"), jsonResponse.lastIndexOf("}") + 1);
+        Configuration confOrgJsonProvider = Configuration.builder().jsonProvider(new JsonOrgJsonProvider()).build();
+
         try {
-            String jsonResponse = RestActions.getLastResponse().asPrettyString();
-            String jsonObject = jsonResponse.substring(jsonResponse.indexOf("{"), jsonResponse.lastIndexOf("}") + 1);
-            Configuration confOrgJsonProvider = Configuration.builder().jsonProvider(new JsonOrgJsonProvider()).build();
-            try {
-                if (jsonPath.contains("?")) {
-                    JSONArray jsonValue = JsonPath.compile(jsonPath).read(new JSONObject(jsonObject), confOrgJsonProvider);
-                    searchPool = String.valueOf(jsonValue.get(0));
-                } else {
-                    Object jsonValue = JsonPath.compile(jsonPath).read(new JSONObject(jsonObject), confOrgJsonProvider);
-                    searchPool = String.valueOf(jsonValue);
-                }
-            } catch (JSONException ex) {
-                FailureReporter.fail(ex.getMessage());
+            if (jsonPath.contains("?")) {
+                JSONArray jsonValue = JsonPath.compile(jsonPath).read(new JSONObject(jsonObject), confOrgJsonProvider);
+                searchPool = String.valueOf(jsonValue.get(0));
+            } else {
+                Object jsonValue = JsonPath.compile(jsonPath).read(new JSONObject(jsonObject), confOrgJsonProvider);
+                searchPool = String.valueOf(jsonValue);
             }
+        } catch (JSONException ex) {
+            FailureReporter.fail(ex.getMessage());
 
         } catch (ClassCastException var4) {
             FailureReporter.fail("Incorrect jsonPath \"" + jsonPath + "\"");

--- a/src/main/java/com/gizasystems/automationexercise/utils/HtmlResponse.java
+++ b/src/main/java/com/gizasystems/automationexercise/utils/HtmlResponse.java
@@ -1,0 +1,55 @@
+package com.gizasystems.automationexercise.utils;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.spi.json.JsonOrgJsonProvider;
+import com.shaft.api.RestActions;
+import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.io.internal.FailureReporter;
+import io.restassured.path.json.exception.JsonPathException;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+
+public class HtmlResponse {
+
+    /**
+     * This implementation is to handle the *PathNotFoundException* that happens when we have json object but inside html or xml tags, so it's not represented as json object
+     * Note: Will delete this class after we implement this logic to SHAFT and have a new release
+     *
+     * @param jsonPath
+     * @return
+     */
+    public static String getResponseJSONValue(String jsonPath) {
+        String searchPool = "";
+        try {
+            String jsonResponse = RestActions.getLastResponse().asPrettyString();
+            String jsonObject = jsonResponse.substring(jsonResponse.indexOf("{"), jsonResponse.lastIndexOf("}") + 1);
+            Configuration confOrgJsonProvider = Configuration.builder().jsonProvider(new JsonOrgJsonProvider()).build();
+            try {
+                if (jsonPath.contains("?")) {
+                    JSONArray jsonValue = JsonPath.compile(jsonPath).read(new JSONObject(jsonObject), confOrgJsonProvider);
+                    searchPool = String.valueOf(jsonValue.get(0));
+                } else {
+                    Object jsonValue = JsonPath.compile(jsonPath).read(new JSONObject(jsonObject), confOrgJsonProvider);
+                    searchPool = String.valueOf(jsonValue);
+                }
+            } catch (JSONException ex) {
+                FailureReporter.fail(ex.getMessage());
+            }
+
+        } catch (ClassCastException var4) {
+            FailureReporter.fail("Incorrect jsonPath \"" + jsonPath + "\"");
+        } catch (IllegalArgumentException | JsonPathException var5) {
+            FailureReporter.fail("Failed to parse the JSON document");
+        }
+
+        if (searchPool != null) {
+            return searchPool;
+        } else {
+            ReportManager.logDiscrete("Either actual value is \"null\" or couldn't find anything that matches with the desired jsonPath \"" + jsonPath + "\"");
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Created **HtmlResponse** java class in the utils package to handle the html response due to the demo website case until we handle it from SHAFT's side and have a new release.

Please make sure to user the getResponseJSONValue static method in your validations while using the native object validation as in the changes reflected to use this method.

```
        SHAFT.Validations.assertThat()
                .object(HtmlResponse.getResponseJSONValue(jsonPath))
                .isEqualTo(expected)
                .perform();
```

[Pipeline run here](https://github.com/MahmoudElSharkawyGS/AutomationExercisePractice/actions/runs/7975469807)

@MostafaAgamyGizaSystems @Abdelrahmangamal371998  
Please make sure to review and merge this PR, and don't forget to pull the latest from master branch after you do so to be able to use this method on your branches.