### PR TITLE
Remove timeStamp from the first test

### DIFF
--- a/src/main/java/com/gizasystems/automationexercise/pages/ProductQuantityPage.java
+++ b/src/main/java/com/gizasystems/automationexercise/pages/ProductQuantityPage.java
@@ -13,7 +13,7 @@ public class ProductQuantityPage {
     private final By hoverBtn_button = By.id("quantity");
     private final By addToCartbtn_Button = By.xpath("//button [@class= 'btn btn-default cart']");
     private final By viewCartbtn_button = By.xpath("//a[@href='/view_cart']/u");
-    private final By productQuantity_button = By.xpath("//td[@class = 'cart_quantity']/button[@class='disabled']");
+    private final By productQuantity_button = By.cssSelector("button[class='disabled']");
 
     // Constructor
     public ProductQuantityPage(SHAFT.GUI.WebDriver driver) {

--- a/src/main/java/com/gizasystems/automationexercise/pages/ProductQuantityPage.java
+++ b/src/main/java/com/gizasystems/automationexercise/pages/ProductQuantityPage.java
@@ -13,7 +13,7 @@ public class ProductQuantityPage {
     private final By hoverBtn_button = By.id("quantity");
     private final By addToCartbtn_Button = By.xpath("//button [@class= 'btn btn-default cart']");
     private final By viewCartbtn_button = By.xpath("//a[@href='/view_cart']/u");
-    private final By productQuantity_button = By.cssSelector("button[class='disabled']");
+    private final By productQuantity_button = By.xpath("//td[@class = 'cart_quantity']/button[@class='disabled']");
 
     // Constructor
     public ProductQuantityPage(SHAFT.GUI.WebDriver driver) {

--- a/src/main/java/com/gizasystems/automationexercise/pages/ProductsPage.java
+++ b/src/main/java/com/gizasystems/automationexercise/pages/ProductsPage.java
@@ -25,7 +25,7 @@ public class ProductsPage {
     private final By searchResult = By.xpath("//div[@class='productinfo text-center']//p");
     private final By viewCartButtonPopUp = By.xpath("//a[@href='/view_cart']//u");
     private final By viewProduct = By.xpath("(//i[@class='fa fa-plus-square'])[1]");
-    private final By writeReviewSection = By.xpath("//li[@class='active']");
+    private final By writeReviewSection = By.xpath("//a[@href='#reviews']");
     private final By reviewerName_input = By.id("name");
     private final By reviewerEmail_input = By.id("email");
     private final By reviewText_input = By.name("review");

--- a/src/main/java/com/gizasystems/automationexercise/pages/ProductsPage.java
+++ b/src/main/java/com/gizasystems/automationexercise/pages/ProductsPage.java
@@ -124,7 +124,7 @@ public class ProductsPage {
 
     @Step("Validate that Review page is displayed")
     public ProductsPage validateVisibilityOfReviewPage() {
-        driver.verifyThat().element(writeReviewSection).textTrimmed().equalsIgnoringCaseSensitivity("Write Your Review").perform();
+        driver.verifyThat().element(writeReviewSection).exists().perform();
         return this;
     }
 

--- a/src/main/java/com/gizasystems/automationexercise/pages/ProductsPage.java
+++ b/src/main/java/com/gizasystems/automationexercise/pages/ProductsPage.java
@@ -25,7 +25,7 @@ public class ProductsPage {
     private final By searchResult = By.xpath("//div[@class='productinfo text-center']//p");
     private final By viewCartButtonPopUp = By.xpath("//a[@href='/view_cart']//u");
     private final By viewProduct = By.xpath("(//i[@class='fa fa-plus-square'])[1]");
-    private final By writeReviewSection = By.xpath("//a[@href='#reviews']");
+    private final By writeReviewSection = By.xpath("//ul[@class='nav nav-tabs']");
     private final By reviewerName_input = By.id("name");
     private final By reviewerEmail_input = By.id("email");
     private final By reviewText_input = By.name("review");

--- a/src/main/java/com/gizasystems/automationexercise/pages/ProductsPage.java
+++ b/src/main/java/com/gizasystems/automationexercise/pages/ProductsPage.java
@@ -124,7 +124,7 @@ public class ProductsPage {
 
     @Step("Validate that Review page is displayed")
     public ProductsPage validateVisibilityOfReviewPage() {
-        driver.verifyThat().element(writeReviewSection).exists().perform();
+        driver.verifyThat().element(writeReviewSection).textTrimmed().equalsIgnoringCaseSensitivity("Write Your Review").perform();
         return this;
     }
 

--- a/src/test/java/com/gizasystems/automationexercise/tests/AddReviewTests.java
+++ b/src/test/java/com/gizasystems/automationexercise/tests/AddReviewTests.java
@@ -29,7 +29,7 @@ public class AddReviewTests {
                 .verifyProductPageTitleVisibility()
                 .clickOnViewProduct()
                 .validateVisibilityOfReviewPage()
-                .addReviewOnProduct(productTestData.getTestData("UserName"), productTestData.getTestData("UserMail.GuiTimeStamp") + timeStamp + "@gizasystems.com", productTestData.getTestData("ReviewText"))
+                .addReviewOnProduct(productTestData.getTestData("UserName"), productTestData.getTestData("UserMail") + timeStamp + "@gizasystems.com", productTestData.getTestData("ReviewText"))
                 .validatethatReviewSuccessAlertIsDisplayed();
     }
 

--- a/src/test/java/com/gizasystems/automationexercise/tests/register/RegisterUserApisTests.java
+++ b/src/test/java/com/gizasystems/automationexercise/tests/register/RegisterUserApisTests.java
@@ -8,8 +8,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.UUID;
-
 @Epic("Automation Exercise")
 @Feature("User Management")
 @Story("Register")

--- a/src/test/java/com/gizasystems/automationexercise/tests/register/RegisterUserApisTests.java
+++ b/src/test/java/com/gizasystems/automationexercise/tests/register/RegisterUserApisTests.java
@@ -22,11 +22,11 @@ public class RegisterUserApisTests {
     @Description("Given that I register with new user, When I enter valid data, Then I should be registered successfully to the system")
     public void registerUserTestApi() {
         new ApisAccountManagement(api)
-                .createRegisterUserAccount(testData.getTestData("UserName"), testData.getTestData("UserMail.Api") + timeStamp + "@gizasystems.com", testData.getTestData("UserPassword"), testData.getTestData("UserFirstName"), testData.getTestData("UserLastName"))
+                .createRegisterUserAccount(testData.getTestData("UserName"), testData.getTestData("UserMail.Api")  + "@gizasystems.com", testData.getTestData("UserPassword"), testData.getTestData("UserFirstName"), testData.getTestData("UserLastName"))
                 .validateUserCreatedRegistered()
-                .deleteUserAccount(testData.getTestData("UserMail.Api") + timeStamp + "@gizasystems.com", testData.getTestData("UserPassword"))
+                .deleteUserAccount(testData.getTestData("UserMail.Api") + "@gizasystems.com", testData.getTestData("UserPassword"))
                 .validateDeleteUser()
-                .validateUserNotFound(testData.getTestData("UserMail.Api") + timeStamp + "@gizasystems.com");
+                .validateUserNotFound(testData.getTestData("UserMail.Api")  + "@gizasystems.com");
     }
 
     @TmsLink("55512219")

--- a/src/test/java/com/gizasystems/automationexercise/tests/register/RegisterUserApisTests.java
+++ b/src/test/java/com/gizasystems/automationexercise/tests/register/RegisterUserApisTests.java
@@ -22,11 +22,11 @@ public class RegisterUserApisTests {
     @Description("Given that I register with new user, When I enter valid data, Then I should be registered successfully to the system")
     public void registerUserTestApi() {
         new ApisAccountManagement(api)
-                .createRegisterUserAccount(testData.getTestData("UserName"), testData.getTestData("UserMail.Api")  + "@gizasystems.com", testData.getTestData("UserPassword"), testData.getTestData("UserFirstName"), testData.getTestData("UserLastName"))
+                .createRegisterUserAccount(testData.getTestData("UserName"), testData.getTestData("UserMail.Api") + timeStamp + "@gizasystems.com", testData.getTestData("UserPassword"), testData.getTestData("UserFirstName"), testData.getTestData("UserLastName"))
                 .validateUserCreatedRegistered()
-                .deleteUserAccount(testData.getTestData("UserMail.Api") + "@gizasystems.com", testData.getTestData("UserPassword"))
+                .deleteUserAccount(testData.getTestData("UserMail.Api") + timeStamp + "@gizasystems.com", testData.getTestData("UserPassword"))
                 .validateDeleteUser()
-                .validateUserNotFound(testData.getTestData("UserMail.Api")  + "@gizasystems.com");
+                .validateUserNotFound(testData.getTestData("UserMail.Api") + timeStamp + "@gizasystems.com");
     }
 
     @TmsLink("55512219")

--- a/src/test/java/com/gizasystems/automationexercise/tests/register/RegisterUserApisTests.java
+++ b/src/test/java/com/gizasystems/automationexercise/tests/register/RegisterUserApisTests.java
@@ -23,7 +23,6 @@ public class RegisterUserApisTests {
     @Test(description = "Register User Test - API")
     @Description("Given that I register with new user, When I enter valid data, Then I should be registered successfully to the system")
     public void registerUserTestApi() {
-        timeStamp = String.valueOf(System.nanoTime());
         new ApisAccountManagement(api)
                 .createRegisterUserAccount(testData.getTestData("UserName"), testData.getTestData("UserMail.Api") + timeStamp + "@gizasystems.com", testData.getTestData("UserPassword"), testData.getTestData("UserFirstName"), testData.getTestData("UserLastName"))
                 .validateUserCreatedRegistered()
@@ -36,7 +35,6 @@ public class RegisterUserApisTests {
     @Test(description = "Register User Test - API - Time Stamp")
     @Description("Given that I register with new user, When I enter valid data, Then I should be registered successfully to the system")
     public void registerUserTestApiTimeStamp() {
-        timeStamp = String.valueOf(System.nanoTime());
         new ApisAccountManagement(api)
                 .createRegisterUserAccount(testData.getTestData("UserName"), testData.getTestData("UserMail.ApiTimeStamp") + timeStamp + "@gizasystems.com", testData.getTestData("UserPassword"), testData.getTestData("UserFirstName"), testData.getTestData("UserLastName"))
                 .validateUserCreatedRegistered();
@@ -50,7 +48,9 @@ public class RegisterUserApisTests {
 
     @BeforeMethod
     public void beforeMethod() {
+        timeStamp = String.valueOf(System.currentTimeMillis());
         api = new SHAFT.API(Apis.ApisBaseUrl);
+
     }
 
 }

--- a/src/test/java/com/gizasystems/automationexercise/tests/register/RegisterUserApisTests.java
+++ b/src/test/java/com/gizasystems/automationexercise/tests/register/RegisterUserApisTests.java
@@ -15,7 +15,7 @@ public class RegisterUserApisTests {
     private SHAFT.API api;
     private SHAFT.TestData.JSON testData;
 
-    private String timeStamp ;
+    private String timeStamp;
 
     @TmsLink("55512219")
     @Test(description = "Register User Test - API")
@@ -48,7 +48,6 @@ public class RegisterUserApisTests {
     public void beforeMethod() {
         timeStamp = String.valueOf(System.currentTimeMillis());
         api = new SHAFT.API(Apis.ApisBaseUrl);
-
     }
 
 }

--- a/src/test/java/com/gizasystems/automationexercise/tests/register/RegisterUserApisTests.java
+++ b/src/test/java/com/gizasystems/automationexercise/tests/register/RegisterUserApisTests.java
@@ -8,6 +8,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.UUID;
+
 @Epic("Automation Exercise")
 @Feature("User Management")
 @Story("Register")
@@ -15,12 +17,13 @@ public class RegisterUserApisTests {
     private SHAFT.API api;
     private SHAFT.TestData.JSON testData;
 
-    private String timeStamp = String.valueOf(System.currentTimeMillis());
+    private String timeStamp ;
 
     @TmsLink("55512219")
     @Test(description = "Register User Test - API")
     @Description("Given that I register with new user, When I enter valid data, Then I should be registered successfully to the system")
     public void registerUserTestApi() {
+        timeStamp = String.valueOf(System.nanoTime());
         new ApisAccountManagement(api)
                 .createRegisterUserAccount(testData.getTestData("UserName"), testData.getTestData("UserMail.Api") + timeStamp + "@gizasystems.com", testData.getTestData("UserPassword"), testData.getTestData("UserFirstName"), testData.getTestData("UserLastName"))
                 .validateUserCreatedRegistered()
@@ -33,6 +36,7 @@ public class RegisterUserApisTests {
     @Test(description = "Register User Test - API - Time Stamp")
     @Description("Given that I register with new user, When I enter valid data, Then I should be registered successfully to the system")
     public void registerUserTestApiTimeStamp() {
+        timeStamp = String.valueOf(System.nanoTime());
         new ApisAccountManagement(api)
                 .createRegisterUserAccount(testData.getTestData("UserName"), testData.getTestData("UserMail.ApiTimeStamp") + timeStamp + "@gizasystems.com", testData.getTestData("UserPassword"), testData.getTestData("UserFirstName"), testData.getTestData("UserLastName"))
                 .validateUserCreatedRegistered();

--- a/src/test/resources/testDataFiles/AddReviewData.json
+++ b/src/test/resources/testDataFiles/AddReviewData.json
@@ -1,11 +1,5 @@
 {
   "ReviewText": "Automation Review",
-  "UserName": "Automation",
-  "UserMail": {
-    "Gui": "AutoBot_Gui",
-    "GuiTimeStamp": "AutoBot_GuiTimeStamp",
-    "GuiApi": "AutoBot_GuiApi",
-    "Api": "AutoBot_Api",
-    "ApiTimeStamp": "AutoBot_ApiTimeStamp"
-  }
+  "UserName": "AutomationReview",
+  "UserMail": "AutoBot_Review"
 }


### PR DESCRIPTION
- Due to parallel execution on edge-windows OS , the second test registerUserTestApiTimeStamp fails with error message [Email already exists], we suggested a solution to remove the timeStamp from the first test to avoid such conflict 